### PR TITLE
consistent attribute

### DIFF
--- a/sections/people.md
+++ b/sections/people.md
@@ -148,7 +148,7 @@ If the account doesn’t allow for more people to be created, a `507 Insufficien
   <title>CEO</title>
   <company-name>Doe Inc.</company-name>
   <background>A popular guy for random data</background>
-  <linkedin_url>http://us.linkedin.com/in/john-doe</linkedin_url>
+  <linkedin-url>http://us.linkedin.com/in/john-doe</linkedin-url>
   <contact-data>
     <email-addresses>
       <email-address>
@@ -205,7 +205,7 @@ Use `?reload=true` to get XML of the successfully updated person.
   <title>CEO</title>
   <company-id>1</company-id>
   <background>A popular guy for random data</background>
-  <linkedin_url>http://us.linkedin.com/in/john-doe</linkedin_url>
+  <linkedin-url>http://us.linkedin.com/in/john-doe</linkedin-url>
   <contact-data>
     <email-addresses>
       <email-address>


### PR DESCRIPTION
Adds consistent attribute for `linkedin-url` replacing a few instances of `linkedin_url`. 